### PR TITLE
Add Ability to Specify Exchange for reqMktData() of Future Symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ ib.connect()
 // Contract
 .contract.combo(symbol, currency, exchange)
 .contract.forex(symbol, currency)
-.contract.future(symbol, expiry, currency)
+.contract.future(symbol, expiry, currency, exchange)
 .contract.option(symbol, expiry, strike, right, exchange, currency)
 .contract.stock(symbol, exchange, currency)
 

--- a/examples/reqMktData.js
+++ b/examples/reqMktData.js
@@ -104,6 +104,9 @@ ib.reqMktData(22, ib.contract.option('AMZN', '201404', 350, 'P'), '', false);
 ib.reqMktData(23, ib.contract.option('GOOG', '201406', 1000, 'C'), '', false);
 ib.reqMktData(24, ib.contract.option('FB', '201406', 50, 'P'), '', false);
 
+// Future
+ib.reqMktData(25, ib.contract.future('ES', '201512', 'USD', 'GLOBEX'), '', false);
+
 // Disconnect after 7 seconds.
 setTimeout(function () {
   console.log('Cancelling market data subscription...'.yellow);
@@ -127,6 +130,9 @@ setTimeout(function () {
   ib.cancelMktData(22);
   ib.cancelMktData(23);
   ib.cancelMktData(24);
+
+  // Future
+  ib.cancelMktData(25);
 
   ib.disconnect();
 }, 7000);

--- a/lib/contract/future.js
+++ b/lib/contract/future.js
@@ -8,13 +8,13 @@ var assert = require('assert');
 
 var _ = require('lodash');
 
-function future(symbol, expiry, currency) {
+function future(symbol, expiry, currency, exchange) {
   assert(_.isString(symbol), 'Symbol must be a string.');
   assert(_.isString(expiry), 'Expiry must be a string.');
 
   return {
     currency: currency || 'USD',
-    exchange: 'ONE',
+    exchange: exchange || 'ONE',
     expiry: expiry,
     secType: 'FUT',
     symbol: symbol


### PR DESCRIPTION
This is a fix for #13. 

It gives the dev the ability to specify the exchange when invoking `reqMktData()`. Specifying the exchange is optional; it falls back on the previous exchange value `ONE` if no value is specified. I've also updated the README and added an example to the `examples/reqMktData.js` file.