### PR TITLE
Fix issue #17. The clientId was not being properly transmitted.

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -27,9 +27,8 @@ Socket.prototype._onConnect = function () {
   this._connected = true;
   this._controller.emit('connected');
 
-  //this._controller.run('sendAsync', [C.CLIENT_VERSION, this._controller.options.clientId]);
-  this._client.write( C.CLIENT_VERSION + EOL );
-  this._client.write( this._controller.options.clientId + EOL );
+  this._controller.run('sendAsync', [C.CLIENT_VERSION]);
+  this._controller.run('sendAsync', [this._controller.options.clientId]);
 };
 
 Socket.prototype._onData = function (data) {

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -27,7 +27,9 @@ Socket.prototype._onConnect = function () {
   this._connected = true;
   this._controller.emit('connected');
 
-  this._controller.run('sendAsync', [C.CLIENT_VERSION, this._controller.options.clientId]);
+  //this._controller.run('sendAsync', [C.CLIENT_VERSION, this._controller.options.clientId]);
+  this._client.write( C.CLIENT_VERSION + EOL );
+  this._client.write( this._controller.options.clientId + EOL );
 };
 
 Socket.prototype._onData = function (data) {


### PR DESCRIPTION
It was being incorrectly grouped with the client version.

Before the fix, `Socket.prototype._onConnect` was transmitting the following via the `sendAsync` call:

```
sending data --> 621
```

After the fix, `Socket.prototype._onConnect` is transmitting the following via two separate `sendAsync` calls:

```
sending data --> 62
sending data --> 1
```

This fix was tested on a multi-worker application, where each worker connects under a different clientId.