### PR TITLE
Resolve buffer underrun issue by adding emitQueue

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,19 @@
+/*
+ * lib/errors.js
+ */
+
+'use strict';
+
+function UnderrunError(message) {
+  this.name = 'UnderrunError';
+  this.message = message || 'An underrun error has occurred';
+  this.stack = (new Error()).stack;
+}
+UnderrunError.prototype = Object.create(Error.prototype);
+UnderrunError.prototype.constructor = UnderrunError;
+
+// Add additional custom error messages here
+
+module.exports = {
+    UnderrunError: UnderrunError
+};

--- a/lib/incoming.js
+++ b/lib/incoming.js
@@ -9,6 +9,7 @@ var util = require('util');
 var _ = require('lodash');
 
 var C = require('./constants');
+var errors = require('./errors');
 
 function Incoming(controller) {
   this._controller = controller;
@@ -1187,11 +1188,9 @@ Incoming.prototype._emit = function () {
   this._emitQueue.push(arguments);
 };
 
-function UnderrunError() { }
-
 Incoming.prototype.dequeue = function () {
   if (this._dataQueue.length == 0) {
-      throw new UnderrunError();
+      throw new errors.UnderrunError();
   }
   var result = this._dataQueue.shift();
   return result;
@@ -1234,7 +1233,7 @@ Incoming.prototype.process = function () {
         this._controller.emitError('Unknown incoming first token: ' + token);
       }
     } catch (e) {
-      if (!e instanceof UnderrunError) {
+      if (!e instanceof errors.UnderrunError) {
           throw e;
       }
       // Put data back in the queue, and don't emit any events.

--- a/lib/incoming.js
+++ b/lib/incoming.js
@@ -14,13 +14,14 @@ function Incoming(controller) {
   this._controller = controller;
 
   this._dataQueue = [];
+  this._emitQueue = [];
 }
 
 Incoming.prototype._ACCT_DOWNLOAD_END = function () {
   var version = this.dequeueInt(),
       accountName = this.dequeue();
 
-  this._controller.emit('accountDownloadEnd', accountName);
+  this._emit('accountDownloadEnd', accountName);
 };
 
 Incoming.prototype._ACCOUNT_SUMMARY = function () {
@@ -31,21 +32,21 @@ Incoming.prototype._ACCOUNT_SUMMARY = function () {
       value = this.dequeue(),
       currency = this.dequeue();
 
-  this._controller.emit('accountSummary', reqId, account, tag, value, currency);
+  this._emit('accountSummary', reqId, account, tag, value, currency);
 };
 
 Incoming.prototype._ACCOUNT_SUMMARY_END = function () {
   var version = this.dequeueInt(),
       reqId = this.dequeueInt();
 
-  this._controller.emit('accountSummaryEnd', reqId);
+  this._emit('accountSummaryEnd', reqId);
 };
 
 Incoming.prototype._ACCT_UPDATE_TIME = function () {
   var version = this.dequeueInt(),
       timeStamp = this.dequeue();
 
-  this._controller.emit('updateAccountTime', timeStamp);
+  this._emit('updateAccountTime', timeStamp);
 };
 
 Incoming.prototype._ACCT_VALUE = function () {
@@ -59,7 +60,7 @@ Incoming.prototype._ACCT_VALUE = function () {
     accountName = this.dequeue();
   }
 
-  this._controller.emit('updateAccountValue', key, value, currency, accountName);
+  this._emit('updateAccountValue', key, value, currency, accountName);
 };
 
 Incoming.prototype._COMMISSION_REPORT = function () {
@@ -73,7 +74,7 @@ Incoming.prototype._COMMISSION_REPORT = function () {
   commissionReport.yield = this.dequeueFloat();
   commissionReport.yieldRedemptionDate = this.dequeueInt();
 
-  this._controller.emit('commissionReport', commissionReport);
+  this._emit('commissionReport', commissionReport);
 };
 
 Incoming.prototype._BOND_CONTRACT_DATA = function () {
@@ -145,7 +146,7 @@ Incoming.prototype._BOND_CONTRACT_DATA = function () {
     }
   }
 
-  this._controller.emit('bondContractDetails', reqId, contract);
+  this._emit('bondContractDetails', reqId, contract);
 };
 
 Incoming.prototype._CONTRACT_DATA = function () {
@@ -221,21 +222,21 @@ Incoming.prototype._CONTRACT_DATA = function () {
     }
   }
 
-  this._controller.emit('contractDetails', reqId, contract);
+  this._emit('contractDetails', reqId, contract);
 };
 
 Incoming.prototype._CONTRACT_DATA_END = function () {
   var version = this.dequeueInt(),
       reqId = this.dequeueInt();
 
-  this._controller.emit('contractDetailsEnd', reqId);
+  this._emit('contractDetailsEnd', reqId);
 };
 
 Incoming.prototype._CURRENT_TIME = function () {
   var version = this.dequeueInt(),
       time = this.dequeueInt();
 
-  this._controller.emit('currentTime', time);
+  this._emit('currentTime', time);
 };
 
 Incoming.prototype._DELTA_NEUTRAL_VALIDATION = function () {
@@ -247,7 +248,7 @@ Incoming.prototype._DELTA_NEUTRAL_VALIDATION = function () {
   underComp.delta = this.dequeueFloat();
   underComp.price = this.dequeueFloat();
 
-  this._controller.emit('deltaNeutralValidation', reqId, underComp);
+  this._emit('deltaNeutralValidation', reqId, underComp);
 };
 
 Incoming.prototype._ERR_MSG = function () {
@@ -343,14 +344,14 @@ Incoming.prototype._EXECUTION_DATA = function () {
     exec.evMultiplier = this.dequeueFloat();
   }
 
-  this._controller.emit('execDetails', reqId, contract, exec);
+  this._emit('execDetails', reqId, contract, exec);
 };
 
 Incoming.prototype._EXECUTION_DATA_END = function () {
   var version = this.dequeueInt(),
       reqId = this.dequeueInt();
 
-  this._controller.emit('execDetailsEnd', reqId);
+  this._emit('execDetailsEnd', reqId);
 };
 
 Incoming.prototype._FUNDAMENTAL_DATA = function () {
@@ -358,7 +359,7 @@ Incoming.prototype._FUNDAMENTAL_DATA = function () {
       reqId = this.dequeueInt(),
       data = this.dequeue();
 
-  this._controller.emit('fundamentalData', reqId, data);
+  this._emit('fundamentalData', reqId, data);
 };
 
 Incoming.prototype._HISTORICAL_DATA = function () {
@@ -400,18 +401,18 @@ Incoming.prototype._HISTORICAL_DATA = function () {
       barCount = this.dequeueInt();
     }
 
-    this._controller.emit('historicalData', reqId, date, open, high, low, close, volume, barCount, WAP, hasGaps);
+    this._emit('historicalData', reqId, date, open, high, low, close, volume, barCount, WAP, hasGaps);
   }
 
   // send end of dataset marker
-  this._controller.emit('historicalData', reqId, completedIndicator, -1, -1, -1, -1, -1, -1, -1, false);
+  this._emit('historicalData', reqId, completedIndicator, -1, -1, -1, -1, -1, -1, -1, false);
 };
 
 Incoming.prototype._MANAGED_ACCTS = function () {
   var version = this.dequeueInt(),
       accountsList = this.dequeue();
 
-  this._controller.emit('managedAccounts', accountsList);
+  this._emit('managedAccounts', accountsList);
 };
 
 Incoming.prototype._MARKET_DATA_TYPE = function () {
@@ -419,7 +420,7 @@ Incoming.prototype._MARKET_DATA_TYPE = function () {
       reqId = this.dequeueInt(),
       marketDataType = this.dequeueInt();
 
-  this._controller.emit('marketDataType', reqId, marketDataType);
+  this._emit('marketDataType', reqId, marketDataType);
 };
 
 Incoming.prototype._MARKET_DEPTH = function () {
@@ -431,7 +432,7 @@ Incoming.prototype._MARKET_DEPTH = function () {
       price = this.dequeueFloat(),
       size = this.dequeueInt();
 
-  this._controller.emit('updateMktDepth', id, position, operation, side, price, size);
+  this._emit('updateMktDepth', id, position, operation, side, price, size);
 };
 
 Incoming.prototype._MARKET_DEPTH_L2 = function () {
@@ -444,7 +445,7 @@ Incoming.prototype._MARKET_DEPTH_L2 = function () {
       price = this.dequeueFloat(),
       size = this.dequeueInt();
 
-  this._controller.emit('updateMktDepthL2', id, position, marketMaker, operation, side, price, size);
+  this._emit('updateMktDepthL2', id, position, marketMaker, operation, side, price, size);
 };
 
 Incoming.prototype._NEWS_BULLETINS = function () {
@@ -454,14 +455,14 @@ Incoming.prototype._NEWS_BULLETINS = function () {
       newsMessage = this.dequeue(),
       originatingExch = this.dequeue();
 
-  this._controller.emit('updateNewsBulletin', newsMsgId, newsMsgType, newsMessage, originatingExch);
+  this._emit('updateNewsBulletin', newsMsgId, newsMsgType, newsMessage, originatingExch);
 };
 
 Incoming.prototype._NEXT_VALID_ID = function () {
   var version = this.dequeueInt(),
       orderId = this.dequeueInt();
 
-  this._controller.emit('nextValidId', orderId);
+  this._emit('nextValidId', orderId);
 };
 
 Incoming.prototype._OPEN_ORDER = function () {
@@ -804,13 +805,13 @@ Incoming.prototype._OPEN_ORDER = function () {
     orderState.warningText = this.dequeue();
   }
 
-  this._controller.emit('openOrder', order.orderId, contract, order, orderState);
+  this._emit('openOrder', order.orderId, contract, order, orderState);
 };
 
 Incoming.prototype._OPEN_ORDER_END = function () {
   var version = this.dequeueInt();
 
-  this._controller.emit('openOrderEnd');
+  this._emit('openOrderEnd');
 };
 
 Incoming.prototype._ORDER_STATUS = function () {
@@ -851,7 +852,7 @@ Incoming.prototype._ORDER_STATUS = function () {
     whyHeld = this.dequeue();
   }
 
-  this._controller.emit('orderStatus', id, status, filled, remaining, avgFillPrice,
+  this._emit('orderStatus', id, status, filled, remaining, avgFillPrice,
                                        permId, parentId, lastFillPrice, clientId, whyHeld);
 };
 
@@ -908,7 +909,7 @@ Incoming.prototype._PORTFOLIO_VALUE = function () {
     contract.primaryExch = this.dequeue();
   }
 
-  this._controller.emit('updatePortfolio', contract, position, marketPrice, marketValue,
+  this._emit('updatePortfolio', contract, position, marketPrice, marketValue,
                                            averageCost, unrealizedPNL, realizedPNL, accountName);
 };
 
@@ -937,13 +938,13 @@ Incoming.prototype._POSITION = function () {
     avgCost = this.dequeueFloat();
   }
 
-  this._controller.emit('position', account, contract, pos, avgCost);
+  this._emit('position', account, contract, pos, avgCost);
 };
 
 Incoming.prototype._POSITION_END = function () {
   var version = this.dequeueInt();
 
-  this._controller.emit('positionEnd');
+  this._emit('positionEnd');
 };
 
 Incoming.prototype._REAL_TIME_BARS = function () {
@@ -958,7 +959,7 @@ Incoming.prototype._REAL_TIME_BARS = function () {
       wap = this.dequeueFloat(),
       count = this.dequeueInt();
 
-  this._controller.emit('realtimeBar', reqId, time, open, high, low, close, volume, wap, count);
+  this._emit('realtimeBar', reqId, time, open, high, low, close, volume, wap, count);
 };
 
 Incoming.prototype._RECEIVE_FA = function () {
@@ -966,7 +967,7 @@ Incoming.prototype._RECEIVE_FA = function () {
       faDataType = this.dequeueInt(),
       xml = this.dequeue();
 
-  this._controller.emit('receiveFA', faDataType, xml);
+  this._emit('receiveFA', faDataType, xml);
 };
 
 Incoming.prototype._SCANNER_DATA = function () {
@@ -1007,18 +1008,18 @@ Incoming.prototype._SCANNER_DATA = function () {
       legsStr = this.dequeue();
     }
 
-    this._controller.emit('scannerData', tickerId, rank, contract, distance,
+    this._emit('scannerData', tickerId, rank, contract, distance,
                                          benchmark, projection, legsStr);
   }
 
-  this._controller.emit('scannerDataEnd', tickerId);
+  this._emit('scannerDataEnd', tickerId);
 };
 
 Incoming.prototype._SCANNER_PARAMETERS = function () {
   var version = this.dequeueInt(),
       xml = this.dequeue();
 
-  this._controller.emit('scannerParameters', xml);
+  this._emit('scannerParameters', xml);
 };
 
 Incoming.prototype._TICK_EFP = function () {
@@ -1033,7 +1034,7 @@ Incoming.prototype._TICK_EFP = function () {
       dividendImpact = this.dequeueFloat(),
       dividendsToExpiry = this.dequeueFloat();
 
-  this._controller.emit('tickEFP', tickerId, tickType, basisPoints, formattedBasisPoints,
+  this._emit('tickEFP', tickerId, tickType, basisPoints, formattedBasisPoints,
                                    impliedFuturesPrice, holdDays, futureExpiry,
                                    dividendImpact, dividendsToExpiry);
 };
@@ -1044,7 +1045,7 @@ Incoming.prototype._TICK_GENERIC = function () {
       tickType = this.dequeueInt(),
       value = this.dequeueFloat();
 
-  this._controller.emit('tickGeneric', tickerId, tickType, value);
+  this._emit('tickGeneric', tickerId, tickType, value);
 };
 
 Incoming.prototype._TICK_OPTION_COMPUTATION = function () {
@@ -1110,7 +1111,7 @@ Incoming.prototype._TICK_OPTION_COMPUTATION = function () {
     }
   }
 
-  this._controller.emit('tickOptionComputation', tickerId, tickType, impliedVol, delta, optPrice, pvDividend, gamma, vega, theta, undPrice);
+  this._emit('tickOptionComputation', tickerId, tickType, impliedVol, delta, optPrice, pvDividend, gamma, vega, theta, undPrice);
 };
 
 Incoming.prototype._TICK_PRICE = function () {
@@ -1130,7 +1131,7 @@ Incoming.prototype._TICK_PRICE = function () {
     canAutoExecute = this.dequeueBool();
   }
 
-  this._controller.emit('tickPrice', tickerId, tickType, price, canAutoExecute);
+  this._emit('tickPrice', tickerId, tickType, price, canAutoExecute);
 
   var sizeTickType = -1;
 
@@ -1152,7 +1153,7 @@ Incoming.prototype._TICK_PRICE = function () {
     }
 
     if (sizeTickType != -1) {
-      this._controller.emit('tickSize', tickerId, sizeTickType, size);
+      this._emit('tickSize', tickerId, sizeTickType, size);
     }
   }
 };
@@ -1163,14 +1164,14 @@ Incoming.prototype._TICK_SIZE = function () {
       tickType = this.dequeueInt(),
       size = this.dequeueInt();
 
-  this._controller.emit('tickSize', tickerId, tickType, size);
+  this._emit('tickSize', tickerId, tickType, size);
 };
 
 Incoming.prototype._TICK_SNAPSHOT_END = function () {
   var version = this.dequeueInt(),
       reqId = this.dequeueInt();
 
-  this._controller.emit('tickSnapshotEnd', reqId);
+  this._emit('tickSnapshotEnd', reqId);
 };
 
 Incoming.prototype._TICK_STRING = function () {
@@ -1179,11 +1180,21 @@ Incoming.prototype._TICK_STRING = function () {
       tickType = this.dequeueInt(),
       value = this.dequeue();
 
-  this._controller.emit('tickString', tickerId, tickType, value);
+  this._emit('tickString', tickerId, tickType, value);
 };
 
+Incoming.prototype._emit = function () {
+  this._emitQueue.push(arguments);
+};
+
+function UnderrunError() { }
+
 Incoming.prototype.dequeue = function () {
-  return this._dataQueue.shift();
+  if (this._dataQueue.length == 0) {
+      throw new UnderrunError();
+  }
+  var result = this._dataQueue.shift();
+  return result;
 };
 
 Incoming.prototype.dequeueBool = function () {
@@ -1204,16 +1215,41 @@ Incoming.prototype.enqueue = function (tokens) {
 
 Incoming.prototype.process = function () {
   var constKey,
-      token;
+      token,
+      dataQueueSnapshot;
 
-  while (token = this.dequeueInt()) {
-    constKey = this._controller._ib.util.incomingToString(token);
-    if (constKey && _.has(this.constructor.prototype, '_' + constKey) && _.isFunction(this['_' + constKey])) {
-      this['_' + constKey]();
-    } else {
-      this._controller.emitError('Unknown incoming first token: ' + token);
+  while (true) {
+    dataQueueSnapshot = this._dataQueue.slice();
+
+    try {
+      // Clear the Emit Queue; if this doesn't get cleared, it piles up whenever there's an error (added by heberallred)
+      this._emitQueue = [];
+
+      token = this.dequeueInt();
+      constKey = this._controller._ib.util.incomingToString(token);
+
+      if (constKey && _.has(this.constructor.prototype, '_' + constKey) && _.isFunction(this['_' + constKey])) {
+        this['_' + constKey]();
+      } else {
+        this._controller.emitError('Unknown incoming first token: ' + token);
+      }
+    } catch (e) {
+      if (!e instanceof UnderrunError) {
+          throw e;
+      }
+      // Put data back in the queue, and don't emit any events.
+      this._dataQueue = this._dataQueue.concat(dataQueueSnapshot);
+      return;
     }
+    // Drain _emitQueue.
+    var self = this;
+    var toEmit = this._emitQueue;
+    this._emitQueue = [];
+    _.forEach(toEmit, function(payload) {
+      self._controller.emit.apply(self._controller, payload);
+    });
   }
+
 };
 
 // Public API

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -21,7 +21,7 @@ function Socket(controller) {
   this._neverReceived = true;
   this._neverSent = true;
   this._waitingAsync = false;
-  this.dataFragment = '';  //added by Heber to prevent partial packets getting lost
+  this.dataFragment = '';  // Prevents partial packets from getting lost (added by heberallred)
 }
 
 Socket.prototype._onConnect = function () {
@@ -91,21 +91,14 @@ Socket.prototype.connect = function () {
   });
 
   this._client.on('data', function () {
-    //console.log('socket.ondata: ', arguments[0].toString());
     self._onData.apply(self, arguments);
   });
 
   this._client.on('end', function () {
-    console.log('socket.onEnd');
     self._onEnd.apply(self, arguments);
   });
 
-  this._client.on('finish', function () {
-    console.log('socket.onFinish!', arguments);
-  });
-
   this._client.on('error', function () {
-    console.log('socket.onError');
     self._onError.apply(self, arguments);
   });
 };

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -21,19 +21,26 @@ function Socket(controller) {
   this._neverReceived = true;
   this._neverSent = true;
   this._waitingAsync = false;
+  this.dataFragment = '';  //added by Heber to prevent partial packets getting lost
 }
 
 Socket.prototype._onConnect = function () {
   this._connected = true;
   this._controller.emit('connected');
 
-  this._controller.run('sendAsync', [C.CLIENT_VERSION]);
-  this._controller.run('sendAsync', [this._controller.options.clientId]);
+  this._controller.run('sendAsync', [C.CLIENT_VERSION, this._controller.options.clientId]);
 };
 
 Socket.prototype._onData = function (data) {
-  var tokens = data.toString().split(EOL).slice(0, -1);
+  var dataWithFragment = this.dataFragment + data.toString();
 
+  var tokens = dataWithFragment.split(EOL); //.slice(0, -1);
+  if (tokens[tokens.length-1] != ''){
+    this.dataFragment = tokens[tokens.length-1];
+  } else {
+    this.dataFragment = '';
+  }
+  tokens = tokens.slice(0, -1);
   this._controller.emit('received', tokens.slice(0), data);
 
   // Process data queue
@@ -42,7 +49,6 @@ Socket.prototype._onData = function (data) {
   if (this._neverReceived) {
     this._controller._serverVersion = parseInt(this._controller._incoming.dequeue(), 10);
     this._controller._serverConnectionTime = this._controller._incoming.dequeue();
-
     this._controller.emit('server', this._controller._serverVersion, this._controller._serverConnectionTime);
   }
 
@@ -85,14 +91,21 @@ Socket.prototype.connect = function () {
   });
 
   this._client.on('data', function () {
+    //console.log('socket.ondata: ', arguments[0].toString());
     self._onData.apply(self, arguments);
   });
 
   this._client.on('end', function () {
+    console.log('socket.onEnd');
     self._onEnd.apply(self, arguments);
   });
 
+  this._client.on('finish', function () {
+    console.log('socket.onFinish!', arguments);
+  });
+
   this._client.on('error', function () {
+    console.log('socket.onError');
     self._onError.apply(self, arguments);
   });
 };


### PR DESCRIPTION
Github user @heberallred gets the credit for solving this one!  Addresses issue #8.

From his fork I checked out `lib/incoming.js` and `lib/socket.js`, cleaned up the code a little bit, and then tested it against the reqHistoricalData test script (posted as a Gist in the comments of #8) that always resulted in buffer underrun errors.

The result is that I'm now consistently getting all historical data with no "Unknown first token" errors or lost packets! If somebody else has a more extensive test suite, I'd really appreciate another pair of eyes on this one.  So far, it looks like this issue has been resolved!

Thanks, @heberallred!