### PR TITLE
Rate limit the requests. Fix #49.

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,6 +3,7 @@ exports.VERSION = 'twsapi_macunix.970.01';
 exports.DEFAULT_HOST = '127.0.0.1';
 exports.DEFAULT_PORT = 7496;
 exports.DEFAULT_CLIENT_ID = 0;
+exports.MAX_REQ_PER_SECOND = 40;
 
 exports.CLIENT_VERSION = 62;
 exports.SERVER_VERSION = 38;

--- a/lib/outgoing.js
+++ b/lib/outgoing.js
@@ -16,7 +16,7 @@ function Outgoing(controller) {
   this._controller = controller;
 }
 
-Outgoing.prototype._send = rateLimit(40, 1000, function () {
+Outgoing.prototype._send = rateLimit(C.MAX_REQ_PER_SECOND, 1000, function () {
   var args = Array.prototype.slice.call(arguments);
   this._controller.run('send', _.flatten(args));
 });

--- a/lib/outgoing.js
+++ b/lib/outgoing.js
@@ -1,5 +1,7 @@
 var _ = require('lodash');
 
+var rateLimit = require('function-rate-limit');
+
 var C = require('./constants');
 
 function _nullifyMax(number) {
@@ -14,10 +16,10 @@ function Outgoing(controller) {
   this._controller = controller;
 }
 
-Outgoing.prototype._send = function () {
+Outgoing.prototype._send = rateLimit(40, 1000, function () {
   var args = Array.prototype.slice.call(arguments);
   this._controller.run('send', _.flatten(args));
-};
+});
 
 Outgoing.prototype.calculateImpliedVolatility = function (reqId, contract, optionPrice, underPrice) {
   if (this._controller._serverVersion < C.MIN_SERVER_VER.REQ_CALC_IMPLIED_VOLAT) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   ],
   "dependencies": {
     "command-buffer": "0.1.0",
-    "lodash": "4.6.1"
+    "lodash": "4.6.1",
+    "function-rate-limit": "1.1.0"
   },
   "devDependencies": {
     "colors": "~0.6.2",


### PR DESCRIPTION
Limiting requests to 40 per second. 45 still generated warnings that we were approaching the max message rate.

PS Please [squash](https://help.github.com/articles/about-pull-request-merge-squashing/) for the merge, thanks

--
Related Issue: #49