### PR TITLE
Improved handling connection close

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -57,8 +57,12 @@ Socket.prototype._onData = function (data) {
 };
 
 Socket.prototype._onEnd = function () {
+  var wasConnected = this._connected;
   this._connected = false;
-  this._controller.emit('disconnected');
+
+  if (wasConnected) {
+    this._controller.emit('disconnected');
+  }
 
   this._controller.resume();
 };
@@ -85,6 +89,10 @@ Socket.prototype.connect = function () {
 
   this._client.on('data', function () {
     self._onData.apply(self, arguments);
+  });
+
+  this._client.on('close', function () {
+    self._onEnd.apply(self, arguments);
   });
 
   this._client.on('end', function () {


### PR DESCRIPTION
Making sure that 'disconnected' is only emitted when the socket transitions from the 'connected' state into the 'disconnected' state. Handling the 'close' event as well.