### PR TITLE
Prevent reconnecting if already connected

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -51,7 +51,11 @@ Controller.prototype._api = function (data) {
 };
 
 Controller.prototype._connect = function () {
-  this._socket.connect();
+  if (!this._socket._connected) {
+    this._socket.connect();
+  } else {
+    this.emitError('Cannot connect if already connected.');
+  }
 };
 
 Controller.prototype._disconnect = function () {


### PR DESCRIPTION
Just like the Controller._disconnect method checks the state of the socket, making the same thing on Controller._connect. Helps prevent issues in which a client might try to connect multiple times with the same client id, which TWS dislikes.