### PR TITLE
Add parentId for STOP orders.

### DIFF
--- a/lib/order/stop.js
+++ b/lib/order/stop.js
@@ -2,20 +2,17 @@ var assert = require('assert');
 
 var _ = require('lodash');
 
-module.exports = function (action, quantity, price, transmitOrder) {
+module.exports = function (action, quantity, price, transmitOrder, parentId) {
   assert(_.isString(action), 'Action must be a string.');
   assert(_.isNumber(quantity), 'Quantity must be a number.');
   assert(_.isNumber(price), 'Price must be a number.');
-
-  if (transmitOrder === undefined) {
-    transmitOrder = true;
-  }
 
   return {
     action: action,
     auxPrice: price,
     orderType: 'STP',
     totalQuantity: quantity,
-    transmit: transmitOrder
+    transmit: transmitOrder || true,
+    parentId: parentId || 0
   };
 };

--- a/lib/order/stopLimit.js
+++ b/lib/order/stopLimit.js
@@ -2,15 +2,11 @@ var assert = require('assert');
 
 var _ = require('lodash');
 
-module.exports = function (action, quantity, limitPrice, stopPrice, transmitOrder) {
+module.exports = function (action, quantity, limitPrice, stopPrice, transmitOrder, parentId) {
   assert(_.isString(action), 'Action must be a string.');
   assert(_.isNumber(quantity), 'Quantity must be a string.');
   assert(_.isNumber(stopPrice), 'Stop price must be a number.');
   assert(_.isNumber(limitPrice), 'Limit price must be a number.');
-
-  if (transmitOrder === undefined) {
-    transmitOrder = true;
-  }
 
   return {
     action: action,
@@ -18,6 +14,7 @@ module.exports = function (action, quantity, limitPrice, stopPrice, transmitOrde
     auxPrice: stopPrice,
     orderType: 'STP LMT',
     totalQuantity: quantity,
-    transmit: transmitOrder
+    transmit: transmitOrder || true,
+    parentId: parentId || 0
   };
 };

--- a/lib/order/trailingStop.js
+++ b/lib/order/trailingStop.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 
 var _ = require('lodash');
 
-module.exports = function (action, quantity, auxPrice, tif, transmitOrder) {
+module.exports = function (action, quantity, auxPrice, tif, transmitOrder, parentId) {
   assert(_.isString(action), 'Action must be a string.');
   assert(_.isNumber(quantity), 'Quantity must be a number.');
   assert(_.isNumber(auxPrice), 'Price must be a number.');
@@ -13,6 +13,7 @@ module.exports = function (action, quantity, auxPrice, tif, transmitOrder) {
     orderType: 'TRAIL',  // https://www.interactivebrokers.com/en/software/api/apiguide/tables/supported_order_types.htm
     auxPrice: auxPrice,
     tif: tif,  // note - TRAIL orders are only triggered during the trading hours of the contract
-    transmit: transmitOrder || true
+    transmit: transmitOrder || true,
+    parentId: parentId || 0
   };
 };


### PR DESCRIPTION
The backend work for attaching STOP orders was already in place, just updating the definitions to support the required arguments.

Also made a slight alteration to use short circuit evaluation for undefined transmitOrder argument.