### PR TITLE
Fix incoming.js so that it will properly re-throw non-underrun errors

### DIFF
--- a/lib/incoming.js
+++ b/lib/incoming.js
@@ -1222,7 +1222,7 @@ Incoming.prototype.process = function () {
         this._controller.emitError('Unknown incoming first token: ' + token);
       }
     } catch (e) {
-      if (!e instanceof errors.UnderrunError) {
+      if (!(e instanceof errors.UnderrunError)) {
         throw e;
       }
       // Put data back in the queue, and don't emit any events.


### PR DESCRIPTION
There's a small precedence issue with this code that is supposed to check if something is an UnderRun error.  If you cause an error in an ib.on("error") handler, it won't notice it and will just put the error back on the stack causing an infinite loop.

Fixing this line causes the original error to be properly thrown and not ignored.

