### PR TITLE
Expose subscriptions to multiple accounts

### DIFF
--- a/lib/incoming.js
+++ b/lib/incoming.js
@@ -17,6 +17,13 @@ Incoming.prototype._ACCT_DOWNLOAD_END = function () {
   this._emit('accountDownloadEnd', accountName);
 };
 
+Incoming.prototype._ACCOUNT_UPDATE_MULTI_END = function () {
+  var version = this.dequeueInt();
+  var requestId = this.dequeue();
+
+  this._emit('accountUpdateMultiEnd', requestId);
+};
+
 Incoming.prototype._ACCOUNT_SUMMARY = function () {
   var version = this.dequeueInt();
   var reqId = this.dequeueInt();
@@ -54,6 +61,18 @@ Incoming.prototype._ACCT_VALUE = function () {
   }
 
   this._emit('updateAccountValue', key, value, currency, accountName);
+};
+
+Incoming.prototype._ACCOUNT_UPDATE_MULTI = function () {
+  var version = this.dequeueInt();
+  var requestId = this.dequeueInt();
+  var account = this.dequeue();
+  var modelCode = this.dequeue();
+  var key = this.dequeue();
+  var value  = this.dequeue();
+  var currency = this.dequeue();
+
+  this._emit('accountUpdateMulti', requestId, account, modelCode, key, value, currency);
 };
 
 Incoming.prototype._COMMISSION_REPORT = function () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,6 +87,15 @@ IB.prototype.cancelHistoricalData = function (tickerId) {
   return this;
 };
 
+IB.prototype.cancelAccountUpdatesMulti = function (reqId) {
+  assert(_.isNumber(reqId), '"reqId" must be an integer - ' + reqId);
+
+  this._send('cancelAccountUpdatesMulti', reqId);
+
+  return this;
+};
+
+
 IB.prototype.cancelMktData = function (tickerId) {
   assert(_.isNumber(tickerId), '"tickerId" must be an integer - ' + tickerId);
 
@@ -190,6 +199,17 @@ IB.prototype.reqAccountUpdates = function (subscribe, acctCode) {
   assert(_.isString(acctCode), '"acctCode" must be a string - ' + acctCode);
 
   this._send('reqAccountUpdates', subscribe, acctCode);
+
+  return this;
+};
+
+IB.prototype.reqAccountUpdatesMulti = function (reqId, acctCode, modelCode, ledgerAndNLV) {
+  assert(_.isNumber(reqId), '"reqId" must be an integer - ' + reqId);
+  assert(_.isString(acctCode), '"acctCode" must be a string - ' + acctCode);
+  assert(_.isString(modelCode), '"modelCode" must be a string - ' + modelCode);
+  assert(_.isBoolean(ledgerAndNLV), '"ledgerAndNLV" must be a boolean - ' + ledgerAndNLV);
+
+  this._send('reqAccountUpdatesMulti', reqId, acctCode, modelCode, ledgerAndNLV);
 
   return this;
 };

--- a/lib/outgoing.js
+++ b/lib/outgoing.js
@@ -147,6 +147,12 @@ Outgoing.prototype.cancelHistoricalData = function (tickerId) {
   this._send(C.OUTGOING.CANCEL_HISTORICAL_DATA, version, tickerId);
 };
 
+Outgoing.prototype.cancelAccountUpdatesMulti = function (reqId) {
+  var version = 2;
+
+  this._send(C.OUTGOING.CANCEL_ACCOUNT_UPDATES_MULTI, version, reqId);
+};
+
 Outgoing.prototype.cancelMktData = function (tickerId) {
   var version = 1;
 
@@ -768,6 +774,11 @@ Outgoing.prototype.reqAccountUpdates = function (subscribe, acctCode) {
   } else {
     this._send(C.OUTGOING.REQ_ACCOUNT_DATA, version, subscribe);
   }
+};
+
+Outgoing.prototype.reqAccountUpdatesMulti = function (requestId, acctCode, modelCode, ledgerAndNLV) {
+  var version = 2;
+  this._send(C.OUTGOING.REQ_ACCOUNT_UPDATES_MULTI, version, requestId, acctCode, modelCode, ledgerAndNLV);
 };
 
 Outgoing.prototype.reqAllOpenOrders = function () {


### PR DESCRIPTION
This PR implements the following methods (signatures are in Typescript):

```typescript
cancelAccountUpdatesMulti(reqId: number): this
reqAccountUpdatesMulti(reqId: number, acctCode: string, modelCode: string, ledgerAndNLV: boolean): this
```

and the following events:

```typescript
on(event: 'accountUpdateMulti', fn: (requestId: number, account: string, modelCode: string, key: string, value: string, currency: string) => void): this
on(event: 'accountUpdateMultiEnd', fn(reqId: number) => void): this
```

I don't understand what `version` means in the `Incoming` and `Outgoing` class, so I ignored it. Perhaps not the smartest move.

The feature was tested with TWS 963.