### PR TITLE
historicalTickBidAskData: fix parameter order for priceAsk and sizeBid

### DIFF
--- a/lib/incoming.js
+++ b/lib/incoming.js
@@ -464,8 +464,8 @@ Incoming.prototype._HISTORICAL_TICKS_BID_ASK = function() {
     date = this.dequeue();
     mask = this.dequeueInt();
     priceBid = this.dequeueFloat();
-    sizeBid = this.dequeueInt();
     priceAsk = this.dequeueFloat();
+    sizeBid = this.dequeueInt();
     sizeAsk = this.dequeueInt();
     this._emit('historicalTickBidAskData', reqId, date, mask, priceBid, priceAsk, sizeBid, sizeAsk);
   }


### PR DESCRIPTION
This PR fixes a bug in the parameter order for `historicalTickBidAskData` that swapped the values of `priceAsk` and `sizeBid`.