### PR TITLE
Wait for incoming token (advisor multi accounts)

### DIFF
--- a/lib/incoming.js
+++ b/lib/incoming.js
@@ -1422,6 +1422,14 @@ Incoming.prototype.dequeueInt = function () {
   return parseInt(this.dequeue(), 10);
 };
 
+Incoming.prototype.dequeueIncoming = function () {
+  var token;
+  do {
+    token = this.dequeue();
+  } while (!token);
+  return parseInt(token, 10);
+};
+
 Incoming.prototype.enqueue = function (tokens) {
   this._dataQueue = this._dataQueue.concat(tokens);
 };
@@ -1438,7 +1446,7 @@ Incoming.prototype.process = function () {
       // Clear the Emit Queue; if this doesn't get cleared, it piles up whenever there's an error (added by heberallred)
       this._emitQueue = [];
 
-      token = this.dequeueInt();
+      token = this.dequeueIncoming();
       constKey = this._controller._ib.util.incomingToString(token);
 
       if (constKey && _.has(this.constructor.prototype, '_' + constKey) && _.isFunction(this['_' + constKey])) {


### PR DESCRIPTION
This PR skips empty tokens on in dequeue when expecting the next incoming token.

I noticed on my IB account when using request reqAccountUpdatesMulti and reqPositionsMulti commands node-ib sometimes emits the error "Unknown incoming first token: NaN" (and fails to process all incoming messages). I traced it down to an empty string in the dequeue. I think this might happen when there is a delay between TWS and the client, which is more likely to happen in advisor accounts.