### PR TITLE
Fix Option Greeks with values > 1.

### DIFF
--- a/lib/incoming.js
+++ b/lib/incoming.js
@@ -536,7 +536,7 @@ Incoming.prototype._TICK_BY_TICK = function () {
       break;
     case 4: // MidPoint
       var midPoint = this.dequeueFloat();
-      
+
       this._emit('tickByTickMidPoint', reqId, time, midPoint);
       break;
   }
@@ -1253,13 +1253,13 @@ Incoming.prototype._TICK_OPTION_COMPUTATION = function () {
   var tickType = this.dequeueInt();
   var impliedVol = this.dequeueFloat();
 
-  if (impliedVol < 0) {  // -1 is the "not yet computed" indicator
+  if (impliedVol == -1) {  // -1 is the "not yet computed" indicator
     impliedVol = Number.MAX_VALUE;
   }
 
   var delta = this.dequeueFloat();
 
-  if (Math.abs(delta) > 1) {  // -2 is the "not yet computed" indicator
+  if (delta == -2) {  // -2 is the "not yet computed" indicator
     delta = Number.MAX_VALUE;
   }
 
@@ -1273,13 +1273,13 @@ Incoming.prototype._TICK_OPTION_COMPUTATION = function () {
   if (version >= 6 || tickType === C.TICK_TYPE.MODEL_OPTION) {  // introduced in version == 5
     optPrice = this.dequeueFloat();
 
-    if (optPrice < 0) {  // -1 is the "not yet computed" indicator
+    if (optPrice == -1) {  // -1 is the "not yet computed" indicator
       optPrice = Number.MAX_VALUE;
     }
 
     pvDividend = this.dequeueFloat();
 
-    if (pvDividend < 0) {  // -1 is the "not yet computed" indicator
+    if (pvDividend == -1) {  // -1 is the "not yet computed" indicator
       pvDividend = Number.MAX_VALUE;
     }
   }
@@ -1287,25 +1287,25 @@ Incoming.prototype._TICK_OPTION_COMPUTATION = function () {
   if (version >= 6) {
     gamma = this.dequeueFloat();
 
-    if (Math.abs(gamma) > 1) {  // -2 is the "not yet computed" indicator
+    if (gamma == -2) {  // -2 is the "not yet computed" indicator
       gamma = Number.MAX_VALUE;
     }
 
     vega = this.dequeueFloat();
 
-    if (Math.abs(vega) > 1) {  // -2 is the "not yet computed" indicator
+    if (vega == -2) {  // -2 is the "not yet computed" indicator
       vega = Number.MAX_VALUE;
     }
 
     theta = this.dequeueFloat();
 
-    if (Math.abs(theta) > 1) {  // -2 is the "not yet computed" indicator
+    if (theta == -2) {  // -2 is the "not yet computed" indicator
       theta = Number.MAX_VALUE;
     }
 
     undPrice = this.dequeueFloat();
 
-    if (undPrice < 0) {  // -1 is the "not yet computed" indicator
+    if (theta == -1) {  // -1 is the "not yet computed" indicator
       undPrice = Number.MAX_VALUE;
     }
   }


### PR DESCRIPTION
During using node-ib for getting option greeks, I have noticed that sometimes there are MAX_VALUE's returned instead of the greek value.
Reason is a check on incoming.js that caps values > 1 to MAX_VALUE.
This is not good, is i.e. vega can be > 1 and so you get MAX_VALUE instead of the actual value.
Did a cross-check with EDecoder.java 	private void processTickOptionComputationMsg() throws IOException from IB SDK, there they also do NOT check abs() > 1, but against the error indicator value.
This PR is about align the JS code with the Java code and fix option greek values > 1.