### PR TITLE
[minor] Add two tick types available since build 970

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -248,7 +248,7 @@ exports.LOG_LEVEL = {
   DETAIL: 5
 };
 
-// constants - tick types
+// constants - tick types from https://interactivebrokers.github.io/tws-api/tick_types.html
 exports.TICK_TYPE = {  
    BID_SIZE:0,
    BID:1,
@@ -337,6 +337,8 @@ exports.TICK_TYPE = {
    LAST_EXCH:84,
    LAST_REG_TIME:85,
    FUTURES_OPEN_INTEREST:86,
+   AVERAGE_OPTION_VOLUME:87,
+   DELAYED_LAST_TIMESTAMP:88,
    UNKNOWN:2147483647
 };
 


### PR DESCRIPTION
Hi @pilwon, this is a super non-controversial PR, trivial to review. Hopefully you can merge and publish a minor version?

Other libraries have appeared (@stoqey/ibkr) but I trust this one much more.